### PR TITLE
Повышение приоритета стилей веб клиента над стилями стороннего контрола

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,7 +89,9 @@ module.exports = (env, argv) => {
     plugins: standaloneMode ? [ new HtmlWebpackPlugin({ template: './index.html' }) ] : 
     [
       new MiniCssExtractPlugin({ 
-        filename: devMode ? "css/[name].css" : "css/[name].[contenthash:8].css"
+        filename: devMode ? 'css/[name].css' : 'css/[name].[contenthash:8].css',
+        // Убрать insert, если требуется поднять приоритет стилей стороннего контрола над стилями веб клиента.
+        insert: linkTag => document.head.prepend(linkTag)
       }),
       new ModuleFederationPlugin({
         name: publicName,


### PR DESCRIPTION
В опции MiniCssExtractPlugin добавлен insert для вставки стилей стороннего контрола в начало тега head страницы. В случае конфликтов стили веб клиента будут иметь приоритет.